### PR TITLE
Switch to menus

### DIFF
--- a/cogs/commands/info/canister.py
+++ b/cogs/commands/info/canister.py
@@ -62,11 +62,9 @@ async def canister(bot, ctx: BlooContext, interaction: bool, whisper: bool, quer
     if not interaction:
         menu = Menu(result, bot, ctx.channel, format_page, False, ctx, False)
         await menu.init_menu()
-        #await bot.get_channel(ctx.channel.id).send(embed=(await TweakMenu(aiter(result), len(result)).format_page(result[0])))
     else:
         menu = Menu(result, bot, ctx.channel, format_page, True, ctx, whisper)
         await menu.init_menu()
-        #await ctx.respond(embed=(await TweakMenu(aiter(result), len(result)).format_page(result[0])), ephemeral=whisper)
 
 class Canister(commands.Cog):
     def __init__(self, bot):

--- a/cogs/commands/info/canister.py
+++ b/cogs/commands/info/canister.py
@@ -58,13 +58,9 @@ async def search(query):
                 return None
 
 async def canister(bot, ctx: BlooContext, interaction: bool, whisper: bool, query: str):
-    result = await search(query)
-    if not interaction:
-        menu = Menu(result, bot, ctx.channel, format_page, False, ctx, False)
-        await menu.init_menu()
-    else:
-        menu = Menu(result, bot, ctx.channel, format_page, True, ctx, whisper)
-        await menu.init_menu()
+    result = list(await search(query))
+    menu = Menu(result, ctx.channel, format_page, interaction, ctx, whisper)
+    await menu.init_menu()
 
 class Canister(commands.Cog):
     def __init__(self, bot):

--- a/utils/menu.py
+++ b/utils/menu.py
@@ -2,9 +2,8 @@ from utils.context import BlooContext
 from utils.views.menu import MenuButtons
 
 class Menu():
-    def __init__(self, pages, bot, channel, format_page, interaction: bool, ctx: BlooContext, whisper: bool):
+    def __init__(self, pages: list, channel, format_page, interaction: bool, ctx: BlooContext, whisper: bool):
         self.pages = pages
-        self.bot = bot
         self.channel = channel
         self.page_formatter = format_page
         self.is_interaction = interaction

--- a/utils/menu.py
+++ b/utils/menu.py
@@ -1,0 +1,16 @@
+from utils.context import BlooContext
+from utils.views.menu import MenuButtons
+
+class Menu():
+    def __init__(self, pages, bot, channel, format_page, interaction: bool, ctx: BlooContext, whisper: bool):
+        self.pages = pages
+        self.bot = bot
+        self.channel = channel
+        self.page_formatter = format_page
+        self.is_interaction = interaction
+        self.ctx = ctx
+        self.should_whisper = whisper
+
+    async def init_menu(self):
+        embed = await self.page_formatter(entry=self.pages[0], all_pages=self.pages, current_page=1)
+        await MenuButtons(self.ctx, self.pages, self.page_formatter, self.channel, self.is_interaction, self.should_whisper).launch(embed)

--- a/utils/menu.py
+++ b/utils/menu.py
@@ -3,6 +3,7 @@ from utils.views.menu import MenuButtons
 
 class Menu():
     def __init__(self, pages: list, channel, format_page, interaction: bool, ctx: BlooContext, whisper: bool):
+        # Declare variables that we need to use globally throughout the menu
         self.pages = pages
         self.channel = channel
         self.page_formatter = format_page
@@ -11,5 +12,7 @@ class Menu():
         self.should_whisper = whisper
 
     async def init_menu(self):
+        # Prepare inital embed
         embed = await self.page_formatter(entry=self.pages[0], all_pages=self.pages, current_page=1)
+        # Initialize our menu
         await MenuButtons(self.ctx, self.pages, self.page_formatter, self.channel, self.is_interaction, self.should_whisper).launch(embed)

--- a/utils/views/menu.py
+++ b/utils/views/menu.py
@@ -4,7 +4,7 @@ from discord.channel import TextChannel
 
 class MenuButtons(ui.View):
     def __init__(self, ctx: BlooContext, pages: list, page_formatter, channel: TextChannel, interaction: bool, whisper: bool):
-        super().__init__()
+        super().__init__(timeout=60)
         self.channel = channel
         self.is_interaction = interaction
         self.should_whisper = whisper
@@ -14,8 +14,10 @@ class MenuButtons(ui.View):
         self.page_formatter = page_formatter
         self.ctx = ctx
         self.msg = None
+        self.embed = None
         
     async def launch(self, embed):
+        self.embed = embed
         self.previous.disabled = True
         self.next.disabled = True
         componentEnabled = False
@@ -57,6 +59,11 @@ class MenuButtons(ui.View):
             embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
             await self.launch(embed)
             
+    @ui.button(emoji='⏹️', style=ButtonStyle.blurple, row=1)
+    async def pause(self, button: ui.Button, interaction: Interaction):
+        if interaction.user == self.ctx.author:
+            await self.on_timeout()
+            
     @ui.button(emoji='➡️', style=ButtonStyle.blurple, row=1, disabled=True)
     async def next(self, button: ui.Button, interaction: Interaction):
         if interaction.user == self.ctx.author:
@@ -64,3 +71,21 @@ class MenuButtons(ui.View):
             self.current_page = (self.current_page + 1)
             embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
             await self.launch(embed)
+
+    async def on_timeout(self):
+        componentEnabled = False
+        if 0 <= (self.array_current_page - 1) < len(self.pages):
+            componentEnabled = True
+        if len(self.pages) > self.current_page:
+            componentEnabled = True
+        if componentEnabled is False:
+            return
+        for child in self.children:
+            child.disabled = True
+        if self.is_interaction is False:
+            await self.msg.edit(embed=self.embed, view=self)
+        else:
+            if self.should_whisper is True:
+                await self.ctx.respond_or_edit(embed=self.embed, view=self, ephemeral=True)
+            else:
+                await self.ctx.respond_or_edit(embed=self.embed, view=self)

--- a/utils/views/menu.py
+++ b/utils/views/menu.py
@@ -1,8 +1,9 @@
-from discord import ButtonStyle, Interaction, SelectOption, ui
+from discord import ButtonStyle, Interaction, ui
 from utils.context import BlooContext
+from discord.channel import TextChannel
 
 class MenuButtons(ui.View):
-    def __init__(self, ctx, pages, page_formatter, channel, interaction: bool, whisper: bool):
+    def __init__(self, ctx: BlooContext, pages: list, page_formatter, channel: TextChannel, interaction: bool, whisper: bool):
         super().__init__()
         self.channel = channel
         self.is_interaction = interaction
@@ -38,9 +39,15 @@ class MenuButtons(ui.View):
                     await self.msg.edit(embed=embed)
         else:
             if componentEnabled is True:
-                await self.ctx.respond_or_edit(embed=embed, view=self, ephemeral=self.should_whisper)
+                if self.should_whisper is True:
+                    await self.ctx.respond_or_edit(embed=embed, view=self, ephemeral=True)
+                else:
+                    await self.ctx.respond_or_edit(embed=embed, view=self)
             else:
-                await self.ctx.respond_or_edit(embed=embed, ephemeral=self.should_whisper)
+                if self.should_whisper is True:
+                    await self.ctx.respond_or_edit(embed=embed, ephemeral=True)
+                else:
+                    await self.ctx.respond_or_edit(embed=embed)
     
     @ui.button(emoji='⬅️', style=ButtonStyle.blurple, row=1, disabled=True)
     async def previous(self, button: ui.Button, interaction: Interaction):

--- a/utils/views/menu.py
+++ b/utils/views/menu.py
@@ -21,6 +21,13 @@ class MenuButtons(ui.View):
     async def launch(self, embed):
         self.embed = embed
         # See which buttons we actually need enabled
+        self.first.disabled = True
+        self.last.disabled = True
+        if len(self.pages) > 1:
+            if self.current_page != len(self.pages):
+                self.last.disabled = False
+            if self.array_current_page != 0:
+                self.first.disabled = False
         self.previous.disabled = True
         self.next.disabled = True
         componentEnabled = False
@@ -59,6 +66,19 @@ class MenuButtons(ui.View):
                 else:
                     await self.ctx.respond_or_edit(embed=embed)
     
+    # Declare first button
+    @ui.button(emoji='⏮️', style=ButtonStyle.blurple, row=1, disabled=True)
+    async def first(self, button: ui.Button, interaction: Interaction):
+        if interaction.user == self.ctx.author:
+            # Set current array page
+            self.array_current_page = 0
+            # Pull down actual current page
+            self.current_page = 1
+            # Prepare our embed
+            embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
+            # Launch!
+            await self.launch(embed)
+    
     # Declare previous button
     @ui.button(emoji='⬅️', style=ButtonStyle.blurple, row=1, disabled=True)
     async def previous(self, button: ui.Button, interaction: Interaction):
@@ -87,6 +107,19 @@ class MenuButtons(ui.View):
             self.array_current_page = (self.array_current_page + 1)
             # Bump up actual current page
             self.current_page = (self.current_page + 1)
+            # Prepare our embed
+            embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
+            # Launch!
+            await self.launch(embed)
+            
+    # Declare last button
+    @ui.button(emoji='⏭️', style=ButtonStyle.blurple, row=1, disabled=True)
+    async def last(self, button: ui.Button, interaction: Interaction):
+        if interaction.user == self.ctx.author:
+            # Set current array page
+            self.array_current_page = (len(self.pages) - 1)
+            # Pull down actual current page
+            self.current_page = (self.array_current_page + 1)
             # Prepare our embed
             embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
             # Launch!

--- a/utils/views/menu.py
+++ b/utils/views/menu.py
@@ -4,7 +4,9 @@ from discord.channel import TextChannel
 
 class MenuButtons(ui.View):
     def __init__(self, ctx: BlooContext, pages: list, page_formatter, channel: TextChannel, interaction: bool, whisper: bool):
+        # Tell buttons to disable after 60 seconds
         super().__init__(timeout=60)
+        # Declare variables that we need to use globally throughout the menu
         self.channel = channel
         self.is_interaction = interaction
         self.should_whisper = whisper
@@ -18,6 +20,7 @@ class MenuButtons(ui.View):
         
     async def launch(self, embed):
         self.embed = embed
+        # See which buttons we actually need enabled
         self.previous.disabled = True
         self.next.disabled = True
         componentEnabled = False
@@ -27,9 +30,11 @@ class MenuButtons(ui.View):
         if len(self.pages) > self.current_page:
             self.next.disabled = False
             componentEnabled = True
-            
+        
+        # If we aren't in an interaction,
         if self.is_interaction is False:
             if self.msg is None:
+                # This is so we don't have buttons needlessly enabled for tweaks with only 1 page
                 if componentEnabled is True:
                     self.msg = await self.channel.send(embed=embed, view=self)
                 else:
@@ -39,7 +44,10 @@ class MenuButtons(ui.View):
                     await self.msg.edit(embed=embed, view=self)
                 else:
                     await self.msg.edit(embed=embed)
+        # Otherwise,
         else:
+            # Handle for an interaction.
+            # This is so we don't have buttons needlessly enabled for tweaks with only 1 page
             if componentEnabled is True:
                 if self.should_whisper is True:
                     await self.ctx.respond_or_edit(embed=embed, view=self, ephemeral=True)
@@ -51,28 +59,42 @@ class MenuButtons(ui.View):
                 else:
                     await self.ctx.respond_or_edit(embed=embed)
     
+    # Declare previous button
     @ui.button(emoji='⬅️', style=ButtonStyle.blurple, row=1, disabled=True)
     async def previous(self, button: ui.Button, interaction: Interaction):
         if interaction.user == self.ctx.author:
+            # Pull down array current page
             self.array_current_page = (self.array_current_page - 1)
+            # Pull down actual current page
             self.current_page = (self.current_page - 1)
+            # Prepare our embed
             embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
+            # Launch!
             await self.launch(embed)
             
+    # Declare stop button
     @ui.button(emoji='⏹️', style=ButtonStyle.blurple, row=1)
     async def pause(self, button: ui.Button, interaction: Interaction):
         if interaction.user == self.ctx.author:
+            # Run our timeout function early
             await self.on_timeout()
             
+    # Declare next button
     @ui.button(emoji='➡️', style=ButtonStyle.blurple, row=1, disabled=True)
     async def next(self, button: ui.Button, interaction: Interaction):
         if interaction.user == self.ctx.author:
+            # Bump up array current page
             self.array_current_page = (self.array_current_page + 1)
+            # Bump up actual current page
             self.current_page = (self.current_page + 1)
+            # Prepare our embed
             embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
+            # Launch!
             await self.launch(embed)
 
+    # Timeout function
     async def on_timeout(self):
+        # Check if we even have any components enabled (if we don't, we don't need to do anything!)
         componentEnabled = False
         if 0 <= (self.array_current_page - 1) < len(self.pages):
             componentEnabled = True
@@ -80,10 +102,15 @@ class MenuButtons(ui.View):
             componentEnabled = True
         if componentEnabled is False:
             return
+
+        # Recursively disable all buttons
         for child in self.children:
             child.disabled = True
+        
+        # If we aren't in an interaction, just edit the current message
         if self.is_interaction is False:
             await self.msg.edit(embed=self.embed, view=self)
+        # Otherwise, handle with context
         else:
             if self.should_whisper is True:
                 await self.ctx.respond_or_edit(embed=self.embed, view=self, ephemeral=True)

--- a/utils/views/menu.py
+++ b/utils/views/menu.py
@@ -1,0 +1,59 @@
+from discord import ButtonStyle, Interaction, SelectOption, ui
+from utils.context import BlooContext
+
+class MenuButtons(ui.View):
+    def __init__(self, ctx, pages, page_formatter, channel, interaction: bool, whisper: bool):
+        super().__init__()
+        self.channel = channel
+        self.is_interaction = interaction
+        self.should_whisper = whisper
+        self.current_page = 1
+        self.array_current_page = 0
+        self.pages = pages
+        self.page_formatter = page_formatter
+        self.ctx = ctx
+        self.msg = None
+        
+    async def launch(self, embed):
+        self.previous.disabled = True
+        self.next.disabled = True
+        componentEnabled = False
+        if 0 <= (self.array_current_page - 1) < len(self.pages):
+            self.previous.disabled = False
+            componentEnabled = True
+        if len(self.pages) > self.current_page:
+            self.next.disabled = False
+            componentEnabled = True
+            
+        if self.is_interaction is False:
+            if self.msg is None:
+                if componentEnabled is True:
+                    self.msg = await self.channel.send(embed=embed, view=self)
+                else:
+                    self.msg = await self.channel.send(embed=embed)
+            else:
+                if componentEnabled is True:
+                    await self.msg.edit(embed=embed, view=self)
+                else:
+                    await self.msg.edit(embed=embed)
+        else:
+            if componentEnabled is True:
+                await self.ctx.respond_or_edit(embed=embed, view=self, ephemeral=self.should_whisper)
+            else:
+                await self.ctx.respond_or_edit(embed=embed, ephemeral=self.should_whisper)
+    
+    @ui.button(emoji='⬅️', style=ButtonStyle.blurple, row=1, disabled=True)
+    async def previous(self, button: ui.Button, interaction: Interaction):
+        if interaction.user == self.ctx.author:
+            self.array_current_page = (self.array_current_page - 1)
+            self.current_page = (self.current_page - 1)
+            embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
+            await self.launch(embed)
+            
+    @ui.button(emoji='➡️', style=ButtonStyle.blurple, row=1, disabled=True)
+    async def next(self, button: ui.Button, interaction: Interaction):
+        if interaction.user == self.ctx.author:
+            self.array_current_page = (self.array_current_page + 1)
+            self.current_page = (self.current_page + 1)
+            embed = await self.page_formatter(entry=self.pages[self.array_current_page], all_pages=self.pages, current_page=self.current_page)
+            await self.launch(embed)


### PR DESCRIPTION
This commit adds menus to the Bloo codebase, which are invokable by using a simple class like so:
```py
async def format_page(entry, all_pages, current_page):
    embed = discord.Embed(title=f"Example embed for page {current_page}/{len(all_pages)}")
    return embed

Menu(result, bot, ctx.channel, format_page, False, ctx, False).init_menu()
```