### PR TITLE
Remove possible raid message after reporting it

### DIFF
--- a/cogs/monitors/antiraid.py
+++ b/cogs/monitors/antiraid.py
@@ -342,6 +342,9 @@ class AntiRaidMonitor(commands.Cog):
 
         # report the user to mods
         await report_raid_phrase(self.bot, message, domain)
+
+        # delete the message so nobody (accidentally) opens it
+        await ctx.message.delete()
             
     async def raid_ban(self, user: discord.Member, reason="Raid phrase detected", dm_user=False):
         """Helper function to ban users"""


### PR DESCRIPTION
Removes the possible raid message after the user being muted, so nobody has the chance to accidentally click it (or do something else idk this is discord)